### PR TITLE
unify wording in about text

### DIFF
--- a/ckanext/lhm/theme_templates/home/snippets/about_text.html
+++ b/ckanext/lhm/theme_templates/home/snippets/about_text.html
@@ -1,5 +1,5 @@
 {% trans %}
-<p>Das Projekt UDP-Katalog hat das Ziel, einen zentralen Metadatenkatalog aller Daten, Dienste und Anwendungen (z.B. Portale) der Urbanen Datenplattform (UDP) und des Münchener Digitalen Zwillings LHM zur Verfügung zu stellen.</p>
+<p>Das Projekt Datengovernance & Metadatenkatalog ist Teil des Programms Digitaler Zwilling München (DZMUC) und hat unter anderem das Ziel, einen zentralen Metadatenkatalog aller Daten, Dienste und Anwendungen (z.B. Portale) der Urbanen Datenplattform (UDP) und des Münchener Digitalen Zwillings zur Verfügung zu stellen.</p>
 <p>Der zentrale Katalog dient als Single-Point of Truth hinsichtlich offener und geschützter Daten und Ressourcen innerhalb der LHM mit Bezug zur Urban Data Plattform, mit dem Ziel:</p>
 <ul>
     <li>eine umfassende Übersicht über die Verfügbarkeit und Nutzbarkeit von Daten und Ressourcen zu erhalten</li>
@@ -8,7 +8,7 @@
 
 <img src="../../../base/images/about/vision.png" alt="Vision des Katalogs" class="vision">
 
-<p>Der Aufbau des UDP-Katalogs soll in mehreren Ausbaustufen erfolgen und dabei ggf. bestehende Lösungen wie den Metadatenkatalog des GeoDatenPool, den Geonetwork Katalog des Geoportals oder den Katalog des Open Data Portals zu integrieren.</p>
+<p>Der Aufbau des Metadatenkatalogs soll in mehreren Ausbaustufen erfolgen und dabei ggf. bestehende Lösungen wie den Metadatenkatalog des GeoDatenPool, den Geonetwork Katalog des Geoportals oder den Katalog des Open Data Portals zu integrieren.</p>
 
 <div class="contact">
     <p>Wenn Sie an unserem Katalog interessiert sind und uns Feedback geben möchten oder Informationen über Ihre Ressourcen bereitstellen möchten, kontaktieren Sie uns bitte unter <a href="mailto:digitaler.zwilling@muenchen.de"> <i>Digitaler Zwilling München</i></a>.</p>

--- a/ckanext/lhm/theme_templates_2.9.9/home/snippets/about_text.html
+++ b/ckanext/lhm/theme_templates_2.9.9/home/snippets/about_text.html
@@ -1,5 +1,5 @@
 {#% trans %#}
-<p>Das Projekt UDP-Katalog hat das Ziel, einen zentralen Metadatenkatalog aller Daten, Dienste und Anwendungen (z.B. Portale) der Urbanen Datenplattform (UDP) und des Münchener Digitalen Zwillings LHM zur Verfügung zu stellen.</p>
+<p>Das Projekt Datengovernance & Metadatenkatalog ist Teil des Programms Digitaler Zwilling München (DZMUC) und hat unter anderem das Ziel, einen zentralen Metadatenkatalog aller Daten, Dienste und Anwendungen (z.B. Portale) der Urbanen Datenplattform (UDP) und des Münchener Digitalen Zwillings zur Verfügung zu stellen.</p>
 <p>Der zentrale Katalog dient als Single-Point of Truth hinsichtlich offener und geschützter Daten und Ressourcen innerhalb der LHM mit Bezug zur Urban Data Plattform, mit dem Ziel:</p>
 <ul>
     <li>eine umfassende Übersicht über die Verfügbarkeit und Nutzbarkeit von Daten und Ressourcen zu erhalten</li>
@@ -8,7 +8,7 @@
 
 <img src="../../../base/images/about/vision.png" alt="Vision des Katalogs" class="vision">
 
-<p>Der Aufbau des UDP-Katalogs soll in mehreren Ausbaustufen erfolgen und dabei ggf. bestehende Lösungen wie den Metadatenkatalog des GeoDatenPool, den Geonetwork Katalog des Geoportals oder den Katalog des Open Data Portals zu integrieren.</p>
+<p>Der Aufbau des Metadatenkatalogs soll in mehreren Ausbaustufen erfolgen und dabei ggf. bestehende Lösungen wie den Metadatenkatalog des GeoDatenPool, den Geonetwork Katalog des Geoportals oder den Katalog des Open Data Portals zu integrieren.</p>
 
 <div class="contact">
     <p>Wenn Sie an unserem Katalog interessiert sind und uns Feedback geben möchten oder Informationen über Ihre Ressourcen bereitstellen möchten, kontaktieren Sie uns bitte unter <a href="{{ h.contact_email() }}"><i>Digitaler Zwilling München</i></a>.</p>


### PR DESCRIPTION
Use Metadatenkatalog instead of UDP-Katalog and current project name.